### PR TITLE
Fix segfault in hexa hash table computation when trying to preview a mesh containing only 1 hexahedra.

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -231,7 +231,12 @@ int hashHexa(pMesh mesh) {
     pp = 0;
     link[l] = 0;
     hvoy[l] = 0;
-    while ( ll != inival ) {
+    /* Remark: test on ll positivity is needed because the part of
+     * hcode array that is initialized (6*mesh->nhex/4) is not
+     * consistent with the part of the array that can be accessed
+     * through keys. In consequences, the travel accross links may end
+     * on a 0 value instead the inival one. */
+    while ( ll>0 && ll != inival ) {
       kk = (ll-1) / 6 +1;
       ii = (ll-1) % 6;
       ph1   = &mesh->hexa[kk];


### PR DESCRIPTION
Medit segfaults when it opens a mesh that contains only 1 hexahedra ([1hexa.mesh.txt](https://github.com/ISCDtoolbox/Medit/files/10075726/1hexa.mesh.txt)).

This segfault occurs during hexa adjacencies computations: first `6*mesh->nhex/4` positions of `hcode` array are initialized with `inival` value while the computed key can acces `max( 2, mesh->nhex )+ 1` first positions. For `mesh->nhex = 1`, for example, the computed key may access the second box of the table while only positions 0 and 1 are initialized to `inival` and second box has value `0`.  Thus, when we travel the built linked list, the list may end on a 0 value instead the expected`inival` one.

This PR adds a simple and robust fix is to add the check of null or negative values to the test of `inival` values to the stopping criterion of the link list travel. The same check already exists in the tetra hash table construction.

Another way to fix this should be to intialized  the `hsize` positions of the `hcode` array, `hsize` being the maximal possible key.