### PR TITLE
fix CMake to add correct glut linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ elseif(UNIX)
 	if(NOT OPENGL_FOUND)
 		message(ERROR " OPENGL not found!")
 	endif(NOT OPENGL_FOUND)
-	set(GL_LIBS ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} )
+	set(GL_LIBS ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} )
 
 	target_link_libraries( Medit3D ${GL_LIBS})
 	INSTALL(               TARGETS Medit3D LIBRARY  DESTINATION "$ENV{HOME}/lib")


### PR DESCRIPTION
In some contexts (e.g. mine, updating to Ubuntu 24.04 LTS), building fails as glut symbols are not found at linking stage - even though Cmake finds glut. As suggested in #5 and #15, the proposed modification in the CMakeLists.txt fixes linker flags.