### PR TITLE
Bug fix - frames from animations now saved as distinct files

### DIFF
--- a/src/menus.c
+++ b/src/menus.c
@@ -265,7 +265,7 @@ void keyFile(unsigned char key,int x,int y) {
       sprintf(data,"%s.%.3d",data,nfree);
     }
     else
-      sprintf(data,"%s.ppm",data);
+	  strcat(data,".ppm");
     if (!saveimg )  glutSetCursor(GLUT_CURSOR_WAIT);
     if ( key == 'B' || key == 'C' || key == 'G' )
       imgTiling(sc,data,key);


### PR DESCRIPTION
Medit was saving the .ppm frames produced by animating a sequence of meshes to one file: ".ppm". This version has fixed this so a series of .ppm files are produced (e.g. heat.1.ppm, heat.2.ppm, etc)

This was due to a line in menus.c overwriting a variable "data" with the file extension ".ppm" instead of concatenating it. The change was to instead use strcat() to append the file extension, preserving the "<name>.<frameid>" format.